### PR TITLE
Feature/bot 690 add disconnect wifi direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,14 @@ Retrieves the current wifi status and passes `true` or `false` to the handler.
 
 Set wifi status. `enabled` is a Boolean type, so to disable the Wifi, you'd execute `WifiWizard.setWifiEnabled(false, win, fail);`
 
-#### `WifiWizard.disconnectWifiDirect(win, fail);
+#### `WifiWizard.disconnectWifiDirect(win, fail);`
 
 Disconnect all Wifi Direct connections. Calls the `win` method if there are no open Wifi Direct connections or the open Wifi Direct connections are terminated. Otherwise, calls fail.
+
 Return values for `win`: `NO_CONNECTION` or `DISCONNECTED`
+
 Return values for `fail`: `ERROR_DISCONNECT_i` or `ERROR_DISCOVERY_i`. Error codes are found [here](https://developer.android.com/reference/android/net/wifi/p2p/WifiP2pManager.ActionListener.html#onFailure(int))
+
 
 ### Changelog:
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Retrieves the current wifi status and passes `true` or `false` to the handler.
 
 Set wifi status. `enabled` is a Boolean type, so to disable the Wifi, you'd execute `WifiWizard.setWifiEnabled(false, win, fail);`
 
+#### `WifiWizard.disconnectWifiDirect(win, fail);
+
+Disconnect all Wifi Direct connections. Calls the `win` method if there are no open Wifi Direct connections or the open Wifi Direct connections are terminated. Otherwise, calls fail.
+Return values for `win`: `NO_CONNECTION` or `DISCONNECTED`
+Return values for `fail`: `ERROR_DISCONNECT_i` or `ERROR_DISCOVERY_i`. Error codes are found [here](https://developer.android.com/reference/android/net/wifi/p2p/WifiP2pManager.ActionListener.html#onFailure(int))
+
 ### Changelog:
 
 #### v0.2.9

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,7 @@
 		</config-file>
 
 	<source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java" target-dir="src/com/pylonproducts/wifiwizard" />
+    <source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java" target-dir="src/com/pylonproducts/wifiwizard" />
     </platform>
 
 	<platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,50 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	id="com.pylonproducts.wifiwizard"
-	version="0.2.11">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="com.pylonproducts.wifiwizard"
+    version="0.2.11">
 
     <name>WifiWizard</name>
     <description>This plugin allows Phonegap applications to manage Wifi connections.</description>
-	<author>Matt Parsons</author>
-	<keywords>phonegap,network,wifi</keywords>
+    <author>Matt Parsons</author>
+    <keywords>phonegap,network,wifi</keywords>
     <license>Apache 2.0</license>
-	<repo>https://github.com/parsonsmatt/WifiWizard/</repo>
+    <repo>https://github.com/parsonsmatt/WifiWizard/</repo>
 
     <js-module src="www/WifiWizard.js" name="WifiWizard">
-    	<clobbers target="window.WifiWizard"/>
+        <clobbers target="window.WifiWizard"/>
     </js-module>
 
     <platform name="android">
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+            <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+        </config-file>
 
-		<config-file target="AndroidManifest.xml" parent="/manifest">
-			<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-			<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-		</config-file>
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="WifiWizard">
+                <param name="android-package" value="com.pylonproducts.wifiwizard.WifiWizard" />
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
 
-		<config-file target="res/xml/config.xml" parent="/*">
-			<feature name="WifiWizard">
-				<param name="android-package" value="com.pylonproducts.wifiwizard.WifiWizard" />
-				<param name="onload" value="true" />
-			</feature>
-		</config-file>
-
-	<source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java" target-dir="src/com/pylonproducts/wifiwizard" />
-    <source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java" target-dir="src/com/pylonproducts/wifiwizard" />
+        <source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java" target-dir="src/com/pylonproducts/wifiwizard" />
+        <source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java" target-dir="src/com/pylonproducts/wifiwizard" />
     </platform>
 
-	<platform name="ios">
-		<config-file target="config.xml" parent="/*">
-			<feature name="WifiWizard">
-				<param name="ios-package" value="NXWWifiWizard"/>
-			</feature>
-		</config-file>
-		
-		<header-file src="src/ios/NXWWifiWizard.h"/>
-		<source-file src="src/ios/NXWWifiWizard.m"/>
-		<framework src="SystemConfiguration.framework" />
-	</platform>
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="WifiWizard">
+                <param name="ios-package" value="NXWWifiWizard"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/NXWWifiWizard.h"/>
+        <source-file src="src/ios/NXWWifiWizard.m"/>
+        <framework src="SystemConfiguration.framework" />
+    </platform>
 
 </plugin>

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
@@ -8,7 +8,6 @@ import org.apache.cordova.*;
 
 import java.util.Collection;
 
-
 public class WifiDirectController {
     private static final String TAG = "WifiWizard";
     private WifiP2pManager wifiP2pManager;
@@ -52,5 +51,3 @@ public class WifiDirectController {
         });
     }
 }
-
-

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
@@ -1,0 +1,71 @@
+package com.pylonproducts.wifiwizard;
+
+import android.net.wifi.p2p.*;
+import android.net.wifi.p2p.WifiP2pManager.*;
+import android.util.Log;
+
+import org.apache.cordova.*;
+
+import java.util.Collection;
+
+
+public class WifiDirectController {
+    private static final String TAG = "WifiWizard";
+    private WifiP2pManager wifiP2pManager;
+    private WifiP2pManager.Channel channel;
+
+    public WifiDirectController(WifiP2pManager manager, WifiP2pManager.Channel channel) {
+        super();
+        this.wifiP2pManager = manager;
+        this.channel = channel;
+    }
+
+    private void removeWifiP2PGroup() {
+        wifiP2pManager.removeGroup(channel, new WifiP2pManager.ActionListener() {
+            @Override
+            public void onSuccess() {
+                // Do nothing
+            }
+            
+            @Override
+            public void onFailure(int reasonCode) {
+                Log.d(TAG, "Disconnect failed. Reason:" + reasonCode);
+            }
+        });
+    }
+
+    public void disconnectAllWifiP2pDevices(CallbackContext callbackContext) {
+        wifiP2pManager.discoverPeers(channel, new WifiP2pManager.ActionListener() {
+            @Override
+            public void onSuccess() {
+                // Do nothing
+            }
+
+            @Override
+            public void onFailure(int reasonCode) {
+                Log.i(TAG, "Peer discovery error: " + reasonCode);
+            }
+        });
+
+        wifiP2pManager.requestPeers(channel, new PeerListListener() {
+            @Override
+            public void onPeersAvailable(WifiP2pDeviceList peerList) {
+
+                Collection<WifiP2pDevice> peers = peerList.getDeviceList();
+
+                if (peers.size() == 0) {
+                    Log.d(TAG, "No devices found");
+                    return;
+                }
+
+                for (WifiP2pDevice wifiP2pDevice : peers) {
+                    if (wifiP2pDevice.status == WifiP2pDevice.CONNECTED) {
+                        removeWifiP2PGroup();
+                    }
+                }
+            }
+        });
+    }
+}
+
+

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
@@ -20,16 +20,20 @@ public class WifiDirectController {
         this.channel = channel;
     }
 
-    private void removeWifiP2PGroup() {
+    private void removeWifiP2pGroup(CallbackContext callbackContext) {
         wifiP2pManager.removeGroup(channel, new WifiP2pManager.ActionListener() {
             @Override
             public void onSuccess() {
-                // Do nothing
+                callbackContext.success("DISCONNECTED")
             }
             
             @Override
             public void onFailure(int reasonCode) {
-                Log.d(TAG, "Disconnect failed. Reason:" + reasonCode);
+                if (reasonCode == WifiP2pManager.BUSY) {
+                    callbackContext.success("NO_CONNECTION");
+                } else {
+                    callbackContext.error("ERROR_DISCONNECT_" + reasonCode);
+                }
             }
         });
     }
@@ -38,31 +42,12 @@ public class WifiDirectController {
         wifiP2pManager.discoverPeers(channel, new WifiP2pManager.ActionListener() {
             @Override
             public void onSuccess() {
-                // Do nothing
+                removeWifiP2pGroup(callbackContext);
             }
 
             @Override
             public void onFailure(int reasonCode) {
-                Log.i(TAG, "Peer discovery error: " + reasonCode);
-            }
-        });
-
-        wifiP2pManager.requestPeers(channel, new PeerListListener() {
-            @Override
-            public void onPeersAvailable(WifiP2pDeviceList peerList) {
-
-                Collection<WifiP2pDevice> peers = peerList.getDeviceList();
-
-                if (peers.size() == 0) {
-                    Log.d(TAG, "No devices found");
-                    return;
-                }
-
-                for (WifiP2pDevice wifiP2pDevice : peers) {
-                    if (wifiP2pDevice.status == WifiP2pDevice.CONNECTED) {
-                        removeWifiP2PGroup();
-                    }
-                }
+                callbackContext.error("ERROR_DISCOVERY_" + reasonCode)
             }
         });
     }

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiDirectController.java
@@ -19,11 +19,11 @@ public class WifiDirectController {
         this.channel = channel;
     }
 
-    private void removeWifiP2pGroup(CallbackContext callbackContext) {
+    private void removeWifiP2pGroup(final CallbackContext callbackContext) {
         wifiP2pManager.removeGroup(channel, new WifiP2pManager.ActionListener() {
             @Override
             public void onSuccess() {
-                callbackContext.success("DISCONNECTED")
+                callbackContext.success("DISCONNECTED");
             }
             
             @Override
@@ -37,7 +37,7 @@ public class WifiDirectController {
         });
     }
 
-    public void disconnectAllWifiP2pDevices(CallbackContext callbackContext) {
+    public void disconnectAllWifiP2pDevices(final CallbackContext callbackContext) {
         wifiP2pManager.discoverPeers(channel, new WifiP2pManager.ActionListener() {
             @Override
             public void onSuccess() {
@@ -46,7 +46,7 @@ public class WifiDirectController {
 
             @Override
             public void onFailure(int reasonCode) {
-                callbackContext.error("ERROR_DISCOVERY_" + reasonCode)
+                callbackContext.error("ERROR_DISCOVERY_" + reasonCode);
             }
         });
     }

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -118,7 +118,8 @@ public class WifiWizard extends CordovaPlugin {
             return this.getConnectedSSID(callbackContext);
         }
         else if(action.equals(DISCONNECT_WIFIDIRECT)) {
-            return this.disconnectWifiDirect(callbackContext);
+            this.disconnectWifiDirect(callbackContext);
+            return true;
         }
         else {
             callbackContext.error("Incorrect action parameter: " + action);
@@ -664,7 +665,7 @@ public class WifiWizard extends CordovaPlugin {
         }
     }
 
-    private boolean disconnectWifiDirect(CallbackContext callbackContext) {
+    private void disconnectWifiDirect(CallbackContext callbackContext) {
         wifiDirectController.disconnectAllWifiP2pDevices(callbackContext);        
     }
 

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -34,6 +34,8 @@ import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiEnterpriseConfig;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiInfo;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.net.wifi.p2p.WifiP2pManager.*;
 import android.util.Log;
 
 
@@ -51,15 +53,22 @@ public class WifiWizard extends CordovaPlugin {
     private static final String GET_CONNECTED_SSID = "getConnectedSSID";
     private static final String IS_WIFI_ENABLED = "isWifiEnabled";
     private static final String SET_WIFI_ENABLED = "setWifiEnabled";
+    private static final String DISCONNECT_WIFIDIRECT = "disconnectWifiDirect";
     private static final String TAG = "WifiWizard";
 
     private WifiManager wifiManager;
     private CallbackContext callbackContext;
+    private WifiP2pManager wifiP2pManager;
+    private Channel channel;
+    private WifiDirectController wifiDirectController;
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         this.wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);
+        this.wifiP2pManager = (WifiP2pManager) cordova.getActivity().getSystemService(Context.WIFI_P2P_SERVICE);
+        this.channel = this.wifiP2pManager.initialize(this, cordova.getActivity().getApplicationContext().getMainLooper(), null);
+        this.wifiDirectManager = new wifiDirectController(wifiP2pManager, channel);
     }
 
     @Override
@@ -107,6 +116,9 @@ public class WifiWizard extends CordovaPlugin {
         }
         else if(action.equals(GET_CONNECTED_SSID)) {
             return this.getConnectedSSID(callbackContext);
+        }
+        else if(action.equals(DISCONNECT_WIFIDIRECT)) {
+            return this.disconnectWifiDirect(callbackContext);
         }
         else {
             callbackContext.error("Incorrect action parameter: " + action);
@@ -650,6 +662,10 @@ public class WifiWizard extends CordovaPlugin {
             callbackContext.error("Cannot enable wifi");
             return false;
         }
+    }
+
+    private boolean disconnectWifiDirect(CallbackContext callbackContext) {
+        wifiDirectController.disconnectAllWifiP2pDevices(callbackContext);        
     }
 
     private boolean validateData(JSONArray data) {

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -38,6 +38,8 @@ import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.*;
 import android.util.Log;
 
+import com.pylonproducts.wifiwizard.WifiDirectController;
+
 
 public class WifiWizard extends CordovaPlugin {
 
@@ -67,8 +69,11 @@ public class WifiWizard extends CordovaPlugin {
         super.initialize(cordova, webView);
         this.wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);
         this.wifiP2pManager = (WifiP2pManager) cordova.getActivity().getSystemService(Context.WIFI_P2P_SERVICE);
-        this.channel = this.wifiP2pManager.initialize(this, cordova.getActivity().getApplicationContext().getMainLooper(), null);
-        this.wifiDirectManager = new wifiDirectController(wifiP2pManager, channel);
+        this.channel = this.wifiP2pManager.initialize(
+                        cordova.getActivity().getApplicationContext(), 
+                        cordova.getActivity().getApplicationContext().getMainLooper(), 
+                        null);
+        this.wifiDirectController = new WifiDirectController(wifiP2pManager, channel);
     }
 
     @Override

--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -38,9 +38,6 @@ import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.*;
 import android.util.Log;
 
-import com.pylonproducts.wifiwizard.WifiDirectController;
-
-
 public class WifiWizard extends CordovaPlugin {
 
     private static final String ADD_NETWORK = "addNetwork";

--- a/www/WifiWizard.js
+++ b/www/WifiWizard.js
@@ -309,6 +309,19 @@ var WifiWizard = {
             return;
         }
         cordova.exec(win, fail, 'WifiWizard', 'setWifiEnabled', [enabled]);
+    },
+
+    /**
+    * Gets 'true' if all Wifi Direct connections are terminated
+    * @param    win     callback function if connections are terminated
+    * @param    fail    callback function if connections could not be terminated
+    */
+    disconnectWifiDirect: function(win, fail) {
+        if (typeof win != "function") {
+            console.log("disconnectWifiDirect second parameter must be a function to handle disconnect result.");
+            return;
+        } 
+        cordova.exec(win, fail, 'WifiWizard', 'disconnectWifiDirect', []);
     }
 };
 


### PR DESCRIPTION
This pull request adds a `disconnectWifiDirect` method to the WifiWizard Cordova plugin. An entrypoint is added in `WifiWizard.js`, which forwards the call to `WifiWizard.java`. The class `WifiDirectController.java` is added to do the actual work.

The changes in `plugin.xml` seem a bit messy. I only added line 34, but I noticed that the spacing was inconsistent. I figured I'd fix this, since I'm sure you would complain about it otherwise.